### PR TITLE
[FEAT] Container 컴포넌트 생성 및 스타일의 적용

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,4 @@
+@import "./styles/reset.css";
 .App {
   text-align: center;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,31 @@
-import React from 'react';
-import logo from './logo.svg';
 import './App.css';
+
+import { Container } from './components/common/layouts/Container'; // Container 컴포넌트 import
+import logo from './logo.svg';
 
 function App() {
   return (
     <div className="App">
       <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
+        <Container
+          maxWidth="1200px"
+          flexDirection="column"
+          justifyContent="center"
+          alignItems="center"
         >
-          Learn React
-        </a>
+          <img src={logo} className="App-logo" alt="logo" />
+          <p>
+            Edit <code>src/App.tsx</code> and save to reload.
+          </p>
+          <a
+            className="App-link"
+            href="https://reactjs.org"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn React
+          </a>
+        </Container>
       </header>
     </div>
   );

--- a/src/components/common/layouts/Container/index.tsx
+++ b/src/components/common/layouts/Container/index.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+import { forwardRef } from 'react';
+
+import { vars } from '@/styles';
+
+type Props = {
+  maxWidth?: string;
+  flexDirection?: 'row' | 'column';
+  justifyContent?: 'center' | 'flex-start' | 'flex-end' | 'space-between' | 'space-around';
+  alignItems?: 'center' | 'flex-start' | 'flex-end' | 'baseline' | 'stretch';
+} & React.HTMLAttributes<HTMLDivElement>;
+
+export const Container: React.FC<Props> = forwardRef(
+  (
+    { children, maxWidth, flexDirection, justifyContent, alignItems, ...props }: Props,
+    ref: React.Ref<HTMLDivElement>,
+  ) => {
+    return (
+      <Wrapper ref={ref} {...props}>
+        <Inner
+          maxWidth={maxWidth}
+          flexDirection={flexDirection}
+          justifyContent={justifyContent}
+          alignItems={alignItems}
+        >
+          {children}
+        </Inner>
+      </Wrapper>
+    );
+  },
+);
+
+const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Inner = styled.div<
+  Pick<Props, 'maxWidth' | 'flexDirection' | 'justifyContent' | 'alignItems'>
+>`
+  width: 100%;
+  max-width: ${({ maxWidth }) => maxWidth ?? vars.breakpoints.md};
+  display: flex;
+  flex-direction: ${({ flexDirection }) => flexDirection ?? 'column'};
+  justify-content: ${({ justifyContent }) => justifyContent ?? 'flex-start'};
+  align-items: ${({ alignItems }) => alignItems ?? 'flex-start'};
+`;

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,3 @@
+import './reset.css';
+
+export * as vars from './variants';

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -1,0 +1,99 @@
+html {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+* {
+  box-sizing: border-box;
+}
+abbr,
+blockquote,
+body,
+button,
+dd,
+dl,
+dt,
+fieldset,
+figure,
+form,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hgroup,
+input,
+legend,
+li,
+ol,
+p,
+pre,
+address,
+caption,
+code,
+figcaption,
+pre,
+th,
+ul {
+  margin: 0;
+  padding: 0;
+  font-weight: 400;
+  font-style: normal;
+}
+
+fieldset,
+iframe {
+  border: 0;
+}
+caption,
+th {
+  text-align: left;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+details,
+main,
+summary {
+  display: block;
+}
+audio,
+canvas,
+progress,
+video {
+  vertical-align: initial;
+}
+button {
+  background: none;
+  border: 0;
+  box-sizing: initial;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  line-height: inherit;
+  overflow: visible;
+  vertical-align: inherit;
+}
+button:disabled {
+  cursor: default;
+}
+:focus {
+  outline: 4px solid rgba(0, 125, 250, 0.6);
+  outline-offset: 1px;
+}
+:focus[data-focus-method='mouse']:not(input):not(textarea):not(select),
+:focus[data-focus-method='touch']:not(input):not(textarea):not(select) {
+  outline: none;
+}
+::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+a {
+  text-decoration: none;
+}
+a:focus {
+  outline: none;
+}

--- a/src/styles/variants/index.ts
+++ b/src/styles/variants/index.ts
@@ -1,0 +1,7 @@
+export const breakpoints = {
+  initial: '0',
+  xs: '520px',
+  sm: '768px',
+  md: '1024px',
+  lg: '1280px',
+};


### PR DESCRIPTION
## 주요 변경사항
1.  `npm install @emotion/styled` 을 통해 설치 후 코드에 해당 부분 적용하였습니다. 
2. Prop 설정 및 div의 모든 기본 HTML 속성도 받을 수 있도록 확장하였습니다. 
3. Container 컴포넌트 생성 
- forwardRef: 부모로부터 전달된 ref를 Wrapper 요소에 전달하여 DOM 참조가 가능하도록 했습니다.
- props 처리
4. 스타일링
- Wrapper와 Inner는 styled-components를 통해 스타일이 적용, props를 사용해 레이아웃을 동적으로 조정 가능합니다.

## 리뷰어에게...
Container 컴포넌트를 생성하는 과정까지 끝이 났는데 정상적으로 적용이 되는지 다시 확인해보아야 할 것 같습니다..
현재 App.tsx 파일에 import를 해보았는데 이렇게 하는게 맞는지 모르겠네용..ㅠ

## 관련 이슈
closes #7 
